### PR TITLE
Fix composer deps + Add composer dependency analyser

### DIFF
--- a/.github/workflows/composer-dependency-analyser.yml
+++ b/.github/workflows/composer-dependency-analyser.yml
@@ -1,0 +1,25 @@
+name: Composer Dependency Analyser
+
+on:
+  workflow_call:
+  pull_request:
+
+jobs:
+  composer-dependency-analyser:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout.
+        uses: actions/checkout@v6
+
+      - name: Install PHP with extensions.
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+          coverage: none
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v3
+
+      - name: Check dependencies
+        run: vendor/bin/composer-dependency-analyser

--- a/composer.json
+++ b/composer.json
@@ -12,28 +12,33 @@
   ],
   "require": {
     "php": ">=8.3",
-    "ext-openssl": "*",
+    "ext-filter": "*",
+    "evenement/evenement": "^3.0",
     "php-mcp/schema": "^1.0",
     "psr/clock": "^1.0",
-    "psr/container": "^1.0 || ^2.0",
-    "psr/container-implementation": "^1.0",
-    "psr/log": "^1.0 || ^2.0 || ^3.0",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.1",
+    "psr/http-message": "^1.1",
+    "psr/http-server-handler": "^1.0",
     "psr/http-server-middleware": "^1.0 || ^2.0 || ^3.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0",
     "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
     "react/event-loop": "^1.5",
     "react/http": "^1.11",
     "react/promise": "^3.0",
+    "react/socket": "^1.17",
     "react/stream": "^1.4"
   },
   "require-dev": {
-    "spiral/code-style": "^2.2",
-    "spiral/core": "^3.15",
     "mockery/mockery": "^1.6",
     "phpunit/phpunit": "^10.5",
-    "rector/rector": "^2.1",
-    "vimeo/psalm": "^6.0",
     "react/async": "^4.0",
-    "react/child-process": "^0.6.6"
+    "react/child-process": "^0.6.6",
+    "rector/rector": "^2.1",
+    "shipmonk/composer-dependency-analyser": "^1.8",
+    "spiral/code-style": "^2.2",
+    "spiral/core": "^3.15",
+    "vimeo/psalm": "^6.0"
   },
   "suggest": {
     "ext-pcntl": "For signal handling support when using StdioServerTransport with StreamSelectLoop"
@@ -51,6 +56,7 @@
   "scripts": {
     "cs-check": "vendor/bin/php-cs-fixer fix --dry-run",
     "cs-fix": "vendor/bin/php-cs-fixer fix",
+    "dependency-analyser": "composer-dependency-analyser",
     "psalm": "vendor/bin/psalm --config=psalm.xml ./src",
     "psalm:ci": "vendor/bin/psalm --config=psalm.xml ./src --output-format=github --shepherd --show-info=false --stats --threads=4 --no-cache",
     "refactor": "rector process --config=rector.php",


### PR DESCRIPTION
This PR introduces dependency analysis tooling and updates the `composer.json` configuration to better reflect actual project requirements.

---

### ✨ Changes included

#### 1. Add dependency analysis tool

* Added `shipmonk/composer-dependency-analyser` to `require-dev`
* Added `dependency-analyser` script to the `scripts` section in `composer.json`

This enables easy local validation of unused and missing dependencies.

---

#### 2. CI integration

* Added GitHub Actions workflow:
  `.github/workflows/composer-dependency-analyser.yml`
* The workflow runs dependency analysis on every pull request

This helps prevent dependency drift and keeps the dependency graph clean over time.

---

#### 3. Update dependencies

##### ➕ Added

* `ext-filter`
* `evenement/evenement`
* `psr/http-client`
* `psr/http-factory`
* `psr/http-message`
* `psr/http-server-handler`
* `react/socket`

These dependencies are required based on actual usage in the codebase.

##### ➖ Removed

* `ext-openssl`
* `psr/container`
* `psr/container-implementation`

These dependencies were identified as unused and removed to reduce unnecessary coupling.

---

### 🎯 Motivation

* Ensure better alignment between declared and actual dependencies
* Improve maintainability and reduce technical debt
* Introduce automated checks to prevent regressions
* Keep the project compliant with best practices in PHP dependency management

---

### 🧪 How to test

Run locally:

```bash
composer dependency-analyser
```

Or open a PR and verify that the GitHub Actions workflow passes.